### PR TITLE
Isolating credentials in tests because the model changes all the time.

### DIFF
--- a/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/DcosCredentials.groovy
+++ b/clouddriver-dcos/src/main/groovy/com/netflix/spinnaker/clouddriver/dcos/DcosCredentials.groovy
@@ -6,7 +6,7 @@ import com.netflix.spinnaker.clouddriver.security.AccountCredentials
 import mesosphere.dcos.client.Config
 import mesosphere.dcos.client.model.DCOSAuthCredentials
 
-import static com.netflix.spinnaker.clouddriver.dcos.DcosConfigurationProperties.*
+import static com.netflix.spinnaker.clouddriver.dcos.DcosConfigurationProperties.LinkedDockerRegistryConfiguration
 
 class DcosCredentials implements AccountCredentials<DCOSAuthCredentials> {
   private static final String CLOUD_PROVIDER = Keys.PROVIDER
@@ -40,14 +40,73 @@ class DcosCredentials implements AccountCredentials<DCOSAuthCredentials> {
     this.dcosClientConfig = dcosClientConfig
   }
 
+  static Builder builder() {
+    return new Builder()
+  }
+
   @JsonIgnore
   @Override
   DCOSAuthCredentials getCredentials() {
-   dcosClientConfig.getCredentials()
+    dcosClientConfig.getCredentials()
   }
 
   @Override
   String getCloudProvider() {
     CLOUD_PROVIDER
+  }
+
+  static class Builder {
+    private String name
+    private String environment
+    private String accountType
+    private List<LinkedDockerRegistryConfiguration> dockerRegistries
+    private List<String> requiredGroupMembership
+    private String dcosUrl
+    private String secretStore
+    private Config dcosClientConfig
+
+    Builder name(String name) {
+      this.name = name
+      return this
+    }
+
+    Builder environment(String environment) {
+      this.environment = environment
+      return this
+    }
+
+    Builder accountType(String accountType) {
+      this.accountType = accountType
+      return this
+    }
+
+    Builder dockerRegistries(List<LinkedDockerRegistryConfiguration> dockerRegistries) {
+      this.dockerRegistries = dockerRegistries
+      return this
+    }
+
+    Builder requiredGroupMembership(List<String> requiredGroupMembership) {
+      this.requiredGroupMembership = requiredGroupMembership
+      return this
+    }
+
+    Builder dcosUrl(String dcosUrl) {
+      this.dcosUrl = dcosUrl
+      return this
+    }
+
+    Builder secretStore(String secretStore) {
+      this.secretStore = secretStore
+      return this
+    }
+
+    Builder dcosClientConfig(Config dcosClientConfig) {
+      this.dcosClientConfig = dcosClientConfig
+      return this
+    }
+
+    DcosCredentials build() {
+      new DcosCredentials(name, environment, accountType, dcosUrl, dockerRegistries, requiredGroupMembership, secretStore, dcosClientConfig)
+    }
   }
 }

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/BaseSpecification.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/BaseSpecification.groovy
@@ -1,0 +1,12 @@
+package com.netflix.spinnaker.clouddriver.dcos.deploy
+
+import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
+import mesosphere.dcos.client.Config
+import spock.lang.Specification
+
+class BaseSpecification extends Specification {
+  def defaultCredentialsBuilder() {
+    DcosCredentials.builder().name('test').environment('test').accountType('test').dcosUrl('https://test.url.com')
+      .secretStore('default').dockerRegistries([]).requiredGroupMembership([]).dcosClientConfig(Config.builder().build())
+  }
+}

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/instance/TerminateDcosInstancesAndDecrementAtomicOperationConverterSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/instance/TerminateDcosInstancesAndDecrementAtomicOperationConverterSpec.groovy
@@ -3,24 +3,20 @@ package com.netflix.spinnaker.clouddriver.dcos.deploy.converters.instance
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.clouddriver.dcos.DcosClientProvider
 import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
+import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.converters.instances.TerminateDcosInstancesAndDecrementAtomicOperationConverter
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.instance.TerminateDcosInstancesAndDecrementDescription
 import com.netflix.spinnaker.clouddriver.dcos.deploy.ops.instance.TerminateDcosInstancesAndDecrementAtomicOperation
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import mesosphere.dcos.client.Config
 import mesosphere.dcos.client.DCOS
-import mesosphere.dcos.client.model.DCOSAuthCredentials
-import spock.lang.Specification
 import spock.lang.Subject
 
-class TerminateDcosInstancesAndDecrementAtomicOperationConverterSpec extends Specification {
+class TerminateDcosInstancesAndDecrementAtomicOperationConverterSpec extends BaseSpecification {
 
     DCOS dcosClient = Mock(DCOS)
 
-    DcosCredentials testCredentials = new DcosCredentials(
-            'test', 'test', 'test', 'https://test.url.com', Config.builder().withCredentials(DCOSAuthCredentials.forUserAccount('user', 'pw')).build()
-    )
+    DcosCredentials testCredentials = defaultCredentialsBuilder().build()
 
     DcosClientProvider dcosClientProvider = Stub(DcosClientProvider) {
         getDcosClient(testCredentials) >> dcosClient

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/instance/TerminateDcosInstancesAtomicOperationConverterSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/instance/TerminateDcosInstancesAtomicOperationConverterSpec.groovy
@@ -3,24 +3,20 @@ package com.netflix.spinnaker.clouddriver.dcos.deploy.converters.instance
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.clouddriver.dcos.DcosClientProvider
 import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
+import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.converters.instances.TerminateDcosInstancesAtomicOperationConverter
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.instance.TerminateDcosInstancesDescription
 import com.netflix.spinnaker.clouddriver.dcos.deploy.ops.instance.TerminateDcosInstancesAtomicOperation
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import mesosphere.dcos.client.Config
 import mesosphere.dcos.client.DCOS
-import mesosphere.dcos.client.model.DCOSAuthCredentials
-import spock.lang.Specification
 import spock.lang.Subject
 
-class TerminateDcosInstancesAtomicOperationConverterSpec extends Specification {
+class TerminateDcosInstancesAtomicOperationConverterSpec extends BaseSpecification {
 
     DCOS dcosClient = Mock(DCOS)
 
-    DcosCredentials testCredentials = new DcosCredentials(
-            'test', 'test', 'test', 'https://test.url.com', Config.builder().withCredentials(DCOSAuthCredentials.forUserAccount('user', 'pw')).build()
-    )
+    DcosCredentials testCredentials = defaultCredentialsBuilder().build()
 
     DcosClientProvider dcosClientProvider = Stub(DcosClientProvider) {
         getDcosClient(testCredentials) >> dcosClient

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/job/RunDcosJobAtomicOperationConverterSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/job/RunDcosJobAtomicOperationConverterSpec.groovy
@@ -3,22 +3,19 @@ package com.netflix.spinnaker.clouddriver.dcos.deploy.converters.job
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.clouddriver.dcos.DcosClientProvider
 import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
+import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.job.RunDcosJobDescription
 import com.netflix.spinnaker.clouddriver.dcos.deploy.ops.job.RunDcosJobAtomicOperation
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import mesosphere.dcos.client.DCOS
-import mesosphere.dcos.client.model.DCOSAuthCredentials
-import spock.lang.Specification
 import spock.lang.Subject
 
-class RunDcosJobAtomicOperationConverterSpec extends Specification {
+class RunDcosJobAtomicOperationConverterSpec extends BaseSpecification {
 
     DCOS dcosClient = Mock(DCOS)
 
-    DcosCredentials testCredentials = new DcosCredentials(
-            'test', 'test', 'test', 'https://test.url.com', DCOSAuthCredentials.forUserAccount('user', 'pw')
-    )
+    DcosCredentials testCredentials = defaultCredentialsBuilder().build()
 
     DcosClientProvider dcosClientProvider = Stub(DcosClientProvider) {
         getDcosClient(testCredentials) >> dcosClient

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/loadbalancer/DeleteDcosLoadBalancerAtomicOperationConverterSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/loadbalancer/DeleteDcosLoadBalancerAtomicOperationConverterSpec.groovy
@@ -3,15 +3,15 @@ package com.netflix.spinnaker.clouddriver.dcos.deploy.converters.loadbalancer
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.clouddriver.dcos.DcosClientProvider
 import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
+import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.loadbalancer.DeleteDcosLoadBalancerAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.dcos.deploy.ops.loadbalancer.DeleteDcosLoadBalancerAtomicOperation
 import com.netflix.spinnaker.clouddriver.dcos.deploy.util.monitor.DcosDeploymentMonitor
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import spock.lang.Shared
-import spock.lang.Specification
 import spock.lang.Subject
 
-class DeleteDcosLoadBalancerAtomicOperationConverterSpec extends Specification {
+class DeleteDcosLoadBalancerAtomicOperationConverterSpec extends BaseSpecification {
 
   private static final ACCOUNT = "my-test-account"
   private static final LOAD_BALANCER_NAME = "external"

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/loadbalancer/UpsertDcosLoadBalancerAtomicOperationConverterSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/loadbalancer/UpsertDcosLoadBalancerAtomicOperationConverterSpec.groovy
@@ -4,15 +4,15 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.clouddriver.dcos.DcosClientProvider
 import com.netflix.spinnaker.clouddriver.dcos.DcosConfigurationProperties
 import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
+import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.loadbalancer.UpsertDcosLoadBalancerAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.dcos.deploy.ops.loadbalancer.UpsertDcosLoadBalancerAtomicOperation
 import com.netflix.spinnaker.clouddriver.dcos.deploy.util.monitor.DcosDeploymentMonitor
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
 import spock.lang.Shared
-import spock.lang.Specification
 import spock.lang.Subject
 
-class UpsertDcosLoadBalancerAtomicOperationConverterSpec extends Specification {
+class UpsertDcosLoadBalancerAtomicOperationConverterSpec extends BaseSpecification {
   private static final ACCOUNT = "my-test-account"
   private static final LOAD_BALANCER_NAME = "external"
 

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/servergroup/DeployDcosServerGroupAtomicOperationConverterSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/servergroup/DeployDcosServerGroupAtomicOperationConverterSpec.groovy
@@ -3,26 +3,22 @@ package com.netflix.spinnaker.clouddriver.dcos.deploy.converters.servergroup
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.clouddriver.dcos.DcosClientProvider
 import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
+import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.servergroup.DeployDcosServerGroupDescription
 import com.netflix.spinnaker.clouddriver.dcos.deploy.ops.servergroup.DeployDcosServerGroupAtomicOperation
 import com.netflix.spinnaker.clouddriver.dcos.deploy.util.mapper.DeployDcosServerGroupDescriptionToAppMapper
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import mesosphere.dcos.client.Config
 import mesosphere.dcos.client.DCOS
-import mesosphere.dcos.client.model.DCOSAuthCredentials
-import spock.lang.Specification
 import spock.lang.Subject
 
-class DeployDcosServerGroupAtomicOperationConverterSpec extends Specification {
+class DeployDcosServerGroupAtomicOperationConverterSpec extends BaseSpecification {
 
   DCOS dcosClient = Mock(DCOS)
   DeployDcosServerGroupDescriptionToAppMapper dcosServerGroupDescriptionToAppMapper = Mock(DeployDcosServerGroupDescriptionToAppMapper)
 
-  DcosCredentials testCredentials = new DcosCredentials(
-    'test', 'test', 'test', 'https://test.url.com', Config.builder().withCredentials(DCOSAuthCredentials.forUserAccount('user', 'pw')).build()
-  )
+  DcosCredentials testCredentials = defaultCredentialsBuilder().build()
 
   DcosClientProvider dcosClientProvider = Stub(DcosClientProvider) {
     getDcosClient(testCredentials) >> dcosClient

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/servergroup/DestroyDcosServerGroupAtomicOperationConverterSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/servergroup/DestroyDcosServerGroupAtomicOperationConverterSpec.groovy
@@ -3,25 +3,21 @@ package com.netflix.spinnaker.clouddriver.dcos.deploy.converters.servergroup
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.clouddriver.dcos.DcosClientProvider
 import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
+import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.AbstractDcosCredentialsDescription
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.servergroup.DestroyDcosServerGroupDescription
 import com.netflix.spinnaker.clouddriver.dcos.deploy.ops.servergroup.DestroyDcosServerGroupAtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import mesosphere.dcos.client.Config
 import mesosphere.dcos.client.DCOS
-import mesosphere.dcos.client.model.DCOSAuthCredentials
-import spock.lang.Specification
 import spock.lang.Subject
 
-class DestroyDcosServerGroupAtomicOperationConverterSpec extends Specification {
+class DestroyDcosServerGroupAtomicOperationConverterSpec extends BaseSpecification {
 
   DCOS dcosClient = Mock(DCOS)
 
-  DcosCredentials testCredentials = new DcosCredentials(
-    'test', 'test', 'test', 'https://test.url.com', Config.builder().withCredentials(DCOSAuthCredentials.forUserAccount('user', 'pw')).build()
-  )
+  DcosCredentials testCredentials = defaultCredentialsBuilder().build()
 
   DcosClientProvider dcosClientProvider = Stub(DcosClientProvider) {
     getDcosClient(testCredentials) >> dcosClient
@@ -39,7 +35,7 @@ class DestroyDcosServerGroupAtomicOperationConverterSpec extends Specification {
     atomicOperationConverter.accountCredentialsProvider = accountCredentialsProvider
     atomicOperationConverter.objectMapper = new ObjectMapper()
     Map input = [
-      credentials: 'test',
+      credentials    : 'test',
       serverGroupName: 'api'
     ]
 
@@ -57,7 +53,7 @@ class DestroyDcosServerGroupAtomicOperationConverterSpec extends Specification {
     atomicOperationConverter.accountCredentialsProvider = accountCredentialsProvider
     atomicOperationConverter.objectMapper = new ObjectMapper()
     Map input = [
-      credentials: 'test',
+      credentials    : 'test',
       serverGroupName: 'api'
     ]
 

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/servergroup/ResizeDcosServerGroupAtomicOperationConverterSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/converters/servergroup/ResizeDcosServerGroupAtomicOperationConverterSpec.groovy
@@ -3,25 +3,21 @@ package com.netflix.spinnaker.clouddriver.dcos.deploy.converters.servergroup
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.clouddriver.dcos.DcosClientProvider
 import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
+import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.AbstractDcosCredentialsDescription
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.servergroup.ResizeDcosServerGroupDescription
 import com.netflix.spinnaker.clouddriver.dcos.deploy.ops.servergroup.ResizeDcosServerGroupAtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import mesosphere.dcos.client.Config
 import mesosphere.dcos.client.DCOS
-import mesosphere.dcos.client.model.DCOSAuthCredentials
-import spock.lang.Specification
 import spock.lang.Subject
 
-class ResizeDcosServerGroupAtomicOperationConverterSpec extends Specification {
+class ResizeDcosServerGroupAtomicOperationConverterSpec extends BaseSpecification {
 
   DCOS dcosClient = Mock(DCOS)
 
-  DcosCredentials testCredentials = new DcosCredentials(
-    'test', 'test', 'test', 'https://test.url.com', Config.builder().withCredentials(DCOSAuthCredentials.forUserAccount('user', 'pw')).build()
-  )
+  DcosCredentials testCredentials = defaultCredentialsBuilder().build()
 
   DcosClientProvider dcosClientProvider = Stub(DcosClientProvider) {
     getDcosClient(testCredentials) >> dcosClient

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/instance/TerminateDcosInstancesAndDecrementAtomicOperationSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/instance/TerminateDcosInstancesAndDecrementAtomicOperationSpec.groovy
@@ -4,20 +4,16 @@ import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.dcos.DcosClientProvider
 import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
+import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.instance.TerminateDcosInstancesAndDecrementDescription
-import mesosphere.dcos.client.Config
 import mesosphere.dcos.client.DCOS
-import mesosphere.dcos.client.model.DCOSAuthCredentials
 import mesosphere.marathon.client.model.v2.GetTasksResponse
 import mesosphere.marathon.client.model.v2.Result
-import spock.lang.Specification
 
-class TerminateDcosInstancesAndDecrementAtomicOperationSpec extends Specification {
+class TerminateDcosInstancesAndDecrementAtomicOperationSpec extends BaseSpecification {
     DCOS dcosClient = Mock(DCOS)
 
-    DcosCredentials testCredentials = new DcosCredentials(
-            'test', 'test', 'test', 'https://test.url.com', Config.builder().withCredentials(DCOSAuthCredentials.forUserAccount('user', 'pw')).build()
-    )
+    DcosCredentials testCredentials = defaultCredentialsBuilder().build()
 
     DcosClientProvider dcosClientProvider = Stub(DcosClientProvider) {
         getDcosClient(testCredentials) >> dcosClient

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/instance/TerminateDcosInstancesAtomicOperationSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/instance/TerminateDcosInstancesAtomicOperationSpec.groovy
@@ -4,20 +4,16 @@ import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.dcos.DcosClientProvider
 import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
+import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.instance.TerminateDcosInstancesDescription
-import mesosphere.dcos.client.Config
 import mesosphere.dcos.client.DCOS
-import mesosphere.dcos.client.model.DCOSAuthCredentials
 import mesosphere.marathon.client.model.v2.DeleteAppTasksResponse
 import mesosphere.marathon.client.model.v2.GetTasksResponse
-import spock.lang.Specification
 
-class TerminateDcosInstancesAtomicOperationSpec extends Specification {
+class TerminateDcosInstancesAtomicOperationSpec extends BaseSpecification {
     DCOS dcosClient = Mock(DCOS)
 
-    DcosCredentials testCredentials = new DcosCredentials(
-            'test', 'test', 'test', 'https://test.url.com', Config.builder().withCredentials(DCOSAuthCredentials.forUserAccount('user', 'pw')).build()
-    )
+    DcosCredentials testCredentials = defaultCredentialsBuilder().build()
 
     DcosClientProvider dcosClientProvider = Stub(DcosClientProvider) {
         getDcosClient(testCredentials) >> dcosClient

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/job/RunDcosJobAtomicOperationSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/job/RunDcosJobAtomicOperationSpec.groovy
@@ -4,19 +4,16 @@ import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.dcos.DcosClientProvider
 import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
+import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.job.RunDcosJobDescription
 import mesosphere.dcos.client.DCOS
-import mesosphere.dcos.client.model.DCOSAuthCredentials
 import mesosphere.metronome.client.model.v1.GetJobResponse
 import mesosphere.metronome.client.model.v1.JobRun
-import spock.lang.Specification
 
-class RunDcosJobAtomicOperationSpec extends Specification {
+class RunDcosJobAtomicOperationSpec extends BaseSpecification {
     DCOS dcosClient = Mock(DCOS)
 
-    DcosCredentials testCredentials = new DcosCredentials(
-            'test', 'test', 'test', 'https://test.url.com', DCOSAuthCredentials.forUserAccount('user', 'pw')
-    )
+    DcosCredentials testCredentials = defaultCredentialsBuilder().build()
 
     DcosClientProvider dcosClientProvider = Stub(DcosClientProvider) {
         getDcosClient(testCredentials) >> dcosClient

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/loadbalancer/DeleteDcosLoadBalancerAtomicOperationSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/loadbalancer/DeleteDcosLoadBalancerAtomicOperationSpec.groovy
@@ -3,18 +3,15 @@ package com.netflix.spinnaker.clouddriver.dcos.deploy.ops.loadbalancer
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.dcos.DcosClientProvider
-import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
+import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.loadbalancer.DeleteDcosLoadBalancerAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.dcos.deploy.util.monitor.DcosDeploymentMonitor
 import com.netflix.spinnaker.clouddriver.dcos.exception.DcosOperationException
-import mesosphere.dcos.client.Config
 import mesosphere.dcos.client.DCOS
-import mesosphere.dcos.client.model.DCOSAuthCredentials
 import mesosphere.marathon.client.model.v2.App
-import spock.lang.Specification
 import spock.lang.Subject
 
-class DeleteDcosLoadBalancerAtomicOperationSpec extends Specification {
+class DeleteDcosLoadBalancerAtomicOperationSpec extends BaseSpecification {
 
   private static final ACCOUNT_NAME = "testaccount"
   private static final LOAD_BALANCER_NAME = "external"
@@ -31,7 +28,7 @@ class DeleteDcosLoadBalancerAtomicOperationSpec extends Specification {
     TaskRepository.threadLocalTask.set(taskMock)
 
     appMock = Mock(App)
-    credentials = new DcosCredentials(ACCOUNT_NAME, "test", "test", "url", Config.builder().withCredentials(DCOSAuthCredentials.forUserAccount('user', 'pw')).build())
+    credentials = defaultCredentialsBuilder().name(ACCOUNT_NAME).build()
     dcosDeploymentMonitorMock = Mock(DcosDeploymentMonitor)
 
     dcosClientMock = Mock(DCOS)
@@ -42,42 +39,42 @@ class DeleteDcosLoadBalancerAtomicOperationSpec extends Specification {
 
   void "DeleteDcosLoadBalancerAtomicOperation should delete the load balancer for the given name if it exists"() {
     setup:
-      appMock.id >> "/${ACCOUNT_NAME}/${LOAD_BALANCER_NAME}"
+    appMock.id >> "/${ACCOUNT_NAME}/${LOAD_BALANCER_NAME}"
 
-      def description = new DeleteDcosLoadBalancerAtomicOperationDescription(
-              credentials: credentials,
-              loadBalancerName: LOAD_BALANCER_NAME
-      )
+    def description = new DeleteDcosLoadBalancerAtomicOperationDescription(
+      credentials: credentials,
+      loadBalancerName: LOAD_BALANCER_NAME
+    )
 
-      @Subject def operation = new DeleteDcosLoadBalancerAtomicOperation(dcosClientProviderMock,
-              dcosDeploymentMonitorMock, description)
+    @Subject def operation = new DeleteDcosLoadBalancerAtomicOperation(dcosClientProviderMock,
+      dcosDeploymentMonitorMock, description)
 
     when:
-      operation.operate([])
+    operation.operate([])
 
     then:
-      1 * dcosClientMock.maybeApp("/${ACCOUNT_NAME}/${LOAD_BALANCER_NAME}") >> Optional.of(appMock)
-      1 * dcosClientMock.deleteApp(appMock.id)
-      1 * dcosDeploymentMonitorMock.waitForAppDestroy(dcosClientMock, appMock, null, taskMock, "DESTROY_LOAD_BALANCER")
+    1 * dcosClientMock.maybeApp("/${ACCOUNT_NAME}/${LOAD_BALANCER_NAME}") >> Optional.of(appMock)
+    1 * dcosClientMock.deleteApp(appMock.id)
+    1 * dcosDeploymentMonitorMock.waitForAppDestroy(dcosClientMock, appMock, null, taskMock, "DESTROY_LOAD_BALANCER")
   }
 
   void "DeleteDcosLoadBalancerAtomicOperation should throw an exception when the given load balancer does not exist"() {
     setup:
-      appMock.id >> "/${ACCOUNT_NAME}/${LOAD_BALANCER_NAME}"
+    appMock.id >> "/${ACCOUNT_NAME}/${LOAD_BALANCER_NAME}"
 
-      def description = new DeleteDcosLoadBalancerAtomicOperationDescription(
-              credentials: credentials,
-              loadBalancerName: LOAD_BALANCER_NAME
-      )
+    def description = new DeleteDcosLoadBalancerAtomicOperationDescription(
+      credentials: credentials,
+      loadBalancerName: LOAD_BALANCER_NAME
+    )
 
-      @Subject def operation = new DeleteDcosLoadBalancerAtomicOperation(dcosClientProviderMock,
-              dcosDeploymentMonitorMock, description)
+    @Subject def operation = new DeleteDcosLoadBalancerAtomicOperation(dcosClientProviderMock,
+      dcosDeploymentMonitorMock, description)
 
     when:
-      operation.operate([])
+    operation.operate([])
 
     then:
-      1 * dcosClientMock.maybeApp("/${ACCOUNT_NAME}/${LOAD_BALANCER_NAME}") >> Optional.empty()
-      thrown(DcosOperationException)
+    1 * dcosClientMock.maybeApp("/${ACCOUNT_NAME}/${LOAD_BALANCER_NAME}") >> Optional.empty()
+    thrown(DcosOperationException)
   }
 }

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/loadbalancer/UpsertDcosLoadBalancerAtomicOperationSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/loadbalancer/UpsertDcosLoadBalancerAtomicOperationSpec.groovy
@@ -6,6 +6,7 @@ import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.dcos.DcosClientProvider
 import com.netflix.spinnaker.clouddriver.dcos.DcosConfigurationProperties
 import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
+import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.loadbalancer.UpsertDcosLoadBalancerAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.dcos.deploy.util.id.DcosSpinnakerLbId
 import com.netflix.spinnaker.clouddriver.dcos.deploy.util.monitor.DcosDeploymentMonitor
@@ -23,7 +24,7 @@ import spock.lang.Subject
 import static com.netflix.spinnaker.clouddriver.dcos.DcosConfigurationProperties.LoadBalancerConfig
 import static com.netflix.spinnaker.clouddriver.dcos.deploy.description.loadbalancer.UpsertDcosLoadBalancerAtomicOperationDescription.PortRange
 
-class UpsertDcosLoadBalancerAtomicOperationSpec extends Specification {
+class UpsertDcosLoadBalancerAtomicOperationSpec extends BaseSpecification {
   private static final ACCOUNT_NAME = "testaccount"
   private static final LOAD_BALANCER_NAME = "external"
   private static final DEPLOYMENT_ID = "deployment-id"
@@ -47,7 +48,7 @@ class UpsertDcosLoadBalancerAtomicOperationSpec extends Specification {
     TaskRepository.threadLocalTask.set(taskMock)
 
     existingAppMock = Mock(App)
-    credentials = new DcosCredentials(ACCOUNT_NAME, "test", "test", "url", Config.builder().withCredentials(DCOSAuthCredentials.forUserAccount('user', 'pw')).build())
+    credentials = defaultCredentialsBuilder().name(ACCOUNT_NAME).build()
     dcosDeploymentMonitorMock = Mock(DcosDeploymentMonitor)
 
     def loadBalancerConfig = Mock(LoadBalancerConfig)

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/servergroup/DeployDcosServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/servergroup/DeployDcosServerGroupAtomicOperationSpec.groovy
@@ -4,27 +4,23 @@ import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.dcos.DcosClientProvider
 import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
-import com.netflix.spinnaker.clouddriver.dcos.deploy.util.id.DcosSpinnakerAppId
+import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.servergroup.DeployDcosServerGroupDescription
+import com.netflix.spinnaker.clouddriver.dcos.deploy.util.id.DcosSpinnakerAppId
 import com.netflix.spinnaker.clouddriver.dcos.deploy.util.mapper.DeployDcosServerGroupDescriptionToAppMapper
 import com.netflix.spinnaker.clouddriver.deploy.DeploymentResult
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
-import mesosphere.dcos.client.Config
 import mesosphere.dcos.client.DCOS
-import mesosphere.dcos.client.model.DCOSAuthCredentials
 import mesosphere.marathon.client.model.v2.*
-import spock.lang.Specification
 import spock.lang.Subject
 
-class DeployDcosServerGroupAtomicOperationSpec extends Specification {
+class DeployDcosServerGroupAtomicOperationSpec extends BaseSpecification {
   private static final APPLICATION_NAME = DcosSpinnakerAppId.parse('/test/region/api-test-detail-v000', true).get()
 
   DCOS mockDcosClient = Mock(DCOS)
   DeployDcosServerGroupDescriptionToAppMapper mockDcosDescriptionToAppMapper = Mock(DeployDcosServerGroupDescriptionToAppMapper)
 
-  DcosCredentials testCredentials = new DcosCredentials(
-    'test', 'test', 'test', 'https://test.url.com', Config.builder().withCredentials(DCOSAuthCredentials.forUserAccount('user', 'pw')).build()
-  )
+  DcosCredentials testCredentials = defaultCredentialsBuilder().build()
 
   DcosClientProvider mockDcosClientProvider = Stub(DcosClientProvider) {
     getDcosClient(testCredentials) >> mockDcosClient

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/servergroup/DestroyDcosServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/servergroup/DestroyDcosServerGroupAtomicOperationSpec.groovy
@@ -4,24 +4,20 @@ import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.dcos.DcosClientProvider
 import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
+import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.servergroup.DestroyDcosServerGroupDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
-import mesosphere.dcos.client.Config
 import mesosphere.dcos.client.DCOS
-import mesosphere.dcos.client.model.DCOSAuthCredentials
 import mesosphere.marathon.client.model.v2.Result
-import spock.lang.Specification
 import spock.lang.Subject
 
-class DestroyDcosServerGroupAtomicOperationSpec extends Specification {
+class DestroyDcosServerGroupAtomicOperationSpec extends BaseSpecification {
   private static final APPLICATION_NAME = 'api-test-v000'
   private static final REGION = 'default'
 
   DCOS dcosClient = Mock(DCOS)
 
-  DcosCredentials testCredentials = new DcosCredentials(
-    'test', 'test', 'test', 'https://test.url.com', Config.builder().withCredentials(DCOSAuthCredentials.forUserAccount('user', 'pw')).build()
-  )
+  DcosCredentials testCredentials = defaultCredentialsBuilder().build()
 
   DcosClientProvider dcosClientProvider = Stub(DcosClientProvider) {
     getDcosClient(testCredentials) >> dcosClient

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/servergroup/ResizeDcosServerGroupAtomicOperationSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/ops/servergroup/ResizeDcosServerGroupAtomicOperationSpec.groovy
@@ -4,24 +4,20 @@ import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.dcos.DcosClientProvider
 import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
+import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.servergroup.ResizeDcosServerGroupDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
-import mesosphere.dcos.client.Config
 import mesosphere.dcos.client.DCOS
-import mesosphere.dcos.client.model.DCOSAuthCredentials
 import mesosphere.marathon.client.model.v2.App
 import mesosphere.marathon.client.model.v2.Result
-import spock.lang.Specification
 import spock.lang.Subject
 
-class ResizeDcosServerGroupAtomicOperationSpec extends Specification {
+class ResizeDcosServerGroupAtomicOperationSpec extends BaseSpecification {
   private static final APPLICATION_NAME = 'api-test-v000'
 
   DCOS dcosClient = Mock(DCOS)
 
-  DcosCredentials testCredentials = new DcosCredentials(
-    'test', 'test', 'test', 'https://test.url.com', Config.builder().withCredentials(DCOSAuthCredentials.forUserAccount('user', 'pw')).build()
-  )
+  DcosCredentials testCredentials = defaultCredentialsBuilder().build()
 
   DcosClientProvider dcosClientProvider = Stub(DcosClientProvider) {
     getDcosClient(testCredentials) >> dcosClient

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/instance/TerminateDcosInstanceAndDecrementDescriptionValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/instance/TerminateDcosInstanceAndDecrementDescriptionValidatorSpec.groovy
@@ -1,21 +1,17 @@
 package com.netflix.spinnaker.clouddriver.dcos.deploy.validators.instance
 
 import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
+import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.instance.TerminateDcosInstancesAndDecrementDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import mesosphere.dcos.client.Config
-import mesosphere.dcos.client.model.DCOSAuthCredentials
 import org.springframework.validation.Errors
-import spock.lang.Specification
 import spock.lang.Subject
 
-class TerminateDcosInstanceAndDecrementDescriptionValidatorSpec extends Specification {
+class TerminateDcosInstanceAndDecrementDescriptionValidatorSpec extends BaseSpecification {
     private static final DESCRIPTION = "terminateDcosInstancesAndDecrementDescription"
 
-    DcosCredentials testCredentials = new DcosCredentials(
-            'test', 'test', 'test', 'https://test.url.com', Config.builder().withCredentials(DCOSAuthCredentials.forUserAccount('user', 'pw')).build()
-    )
+    DcosCredentials testCredentials = defaultCredentialsBuilder().build()
 
     AccountCredentialsProvider accountCredentialsProvider = Stub(AccountCredentialsProvider) {
         getCredentials('test') >> testCredentials
@@ -43,7 +39,7 @@ class TerminateDcosInstanceAndDecrementDescriptionValidatorSpec extends Specific
 
     void "validate should give errors when given a TerminateDcosInstancesAndDecrementDescription with only an appId"() {
         setup:
-            def description = new TerminateDcosInstancesAndDecrementDescription(credentials: new DcosCredentials(null, null, null, null, null),
+            def description = new TerminateDcosInstancesAndDecrementDescription(credentials: defaultCredentialsBuilder().name(null).build(),
                     appId: "test/region/app-stack-detail-v000", hostId: null, taskIds: [], force: false)
             def errorsMock = Mock(Errors)
         when:

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/instance/TerminateDcosInstanceDescriptionValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/instance/TerminateDcosInstanceDescriptionValidatorSpec.groovy
@@ -1,21 +1,17 @@
 package com.netflix.spinnaker.clouddriver.dcos.deploy.validators.instance
 
 import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
+import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.instance.TerminateDcosInstancesDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import mesosphere.dcos.client.Config
-import mesosphere.dcos.client.model.DCOSAuthCredentials
 import org.springframework.validation.Errors
-import spock.lang.Specification
 import spock.lang.Subject
 
-class TerminateDcosInstanceDescriptionValidatorSpec extends Specification {
+class TerminateDcosInstanceDescriptionValidatorSpec extends BaseSpecification {
     private static final DESCRIPTION = "terminateDcosInstancesDescription"
 
-    DcosCredentials testCredentials = new DcosCredentials(
-            'test', 'test', 'test', 'https://test.url.com', Config.builder().withCredentials(DCOSAuthCredentials.forUserAccount('user', 'pw')).build()
-    )
+    DcosCredentials testCredentials = defaultCredentialsBuilder().build()
 
     AccountCredentialsProvider accountCredentialsProvider = Stub(AccountCredentialsProvider) {
         getCredentials('test') >> testCredentials
@@ -43,7 +39,7 @@ class TerminateDcosInstanceDescriptionValidatorSpec extends Specification {
 
     void "validate should give errors when given a TerminateDcosInstancesDescription with only an appId"() {
         setup:
-            def description = new TerminateDcosInstancesDescription(credentials: new DcosCredentials(null, null, null, null, null),
+            def description = new TerminateDcosInstancesDescription(credentials: defaultCredentialsBuilder().name(null).build(),
                     appId: "test/region/app-stack-detail-v000", hostId: null, taskIds: [], force: false, wipe: false)
             def errorsMock = Mock(Errors)
         when:

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/job/RunDcosJobValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/job/RunDcosJobValidatorSpec.groovy
@@ -1,20 +1,17 @@
 package com.netflix.spinnaker.clouddriver.dcos.deploy.validators.job
 
 import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
+import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.job.RunDcosJobDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import mesosphere.dcos.client.model.DCOSAuthCredentials
 import org.springframework.validation.Errors
-import spock.lang.Specification
 import spock.lang.Subject
 
-class RunDcosJobValidatorSpec extends Specification {
+class RunDcosJobValidatorSpec extends BaseSpecification {
     private static final DESCRIPTION = "runDcosJobDescription"
 
-    DcosCredentials testCredentials = new DcosCredentials(
-            'test', 'test', 'test', 'https://test.url.com', DCOSAuthCredentials.forUserAccount('user', 'pw')
-    )
+    DcosCredentials testCredentials = defaultCredentialsBuilder().build()
 
     AccountCredentialsProvider accountCredentialsProvider = Stub(AccountCredentialsProvider) {
         getCredentials('test') >> testCredentials
@@ -39,7 +36,7 @@ class RunDcosJobValidatorSpec extends Specification {
 
     void "validate should give errors when given a RunDcosJobDescription with invalid credentials and an invalid id"() {
         setup:
-            def description = new RunDcosJobDescription(credentials: new DcosCredentials(null, null, null, null, null),
+            def description = new RunDcosJobDescription(credentials: defaultCredentialsBuilder().name(null).build(),
                     general: new RunDcosJobDescription.GeneralSettings().with {
                         id = '/iNv.aLiD-'
                         it

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/loadbalancer/DeleteDcosLoadBalancerAtomicOperationDescriptionValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/loadbalancer/DeleteDcosLoadBalancerAtomicOperationDescriptionValidatorSpec.groovy
@@ -1,16 +1,14 @@
 package com.netflix.spinnaker.clouddriver.dcos.deploy.validators.loadbalancer
 
 import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
+import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.loadbalancer.DeleteDcosLoadBalancerAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import mesosphere.dcos.client.Config
-import mesosphere.dcos.client.model.DCOSAuthCredentials
 import org.springframework.validation.Errors
 import spock.lang.Shared
-import spock.lang.Specification
 import spock.lang.Subject
 
-class DeleteDcosLoadBalancerAtomicOperationDescriptionValidatorSpec extends Specification {
+class DeleteDcosLoadBalancerAtomicOperationDescriptionValidatorSpec extends BaseSpecification {
 
   private static final DESCRIPTION = "deleteDcosLoadBalancerAtomicOperationDescription"
   private static final ACCOUNT = "my-test-account"
@@ -20,9 +18,7 @@ class DeleteDcosLoadBalancerAtomicOperationDescriptionValidatorSpec extends Spec
   DeleteDcosLoadBalancerAtomicOperationDescriptionValidator validator
 
   @Shared
-  DcosCredentials testCredentials = new DcosCredentials(
-          ACCOUNT, 'test', 'test', 'url', Config.builder().withCredentials(DCOSAuthCredentials.forUserAccount('user', 'pw')).build()
-  )
+  DcosCredentials testCredentials = defaultCredentialsBuilder().name(ACCOUNT).build()
 
   def setupSpec() {
     def accountCredentialsProvider = Stub(AccountCredentialsProvider) {

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/loadbalancer/UpsertDcosLoadBalancerAtomicOperationDescriptionValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/loadbalancer/UpsertDcosLoadBalancerAtomicOperationDescriptionValidatorSpec.groovy
@@ -1,18 +1,16 @@
 package com.netflix.spinnaker.clouddriver.dcos.deploy.validators.loadbalancer
 
 import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
+import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.loadbalancer.UpsertDcosLoadBalancerAtomicOperationDescription
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import mesosphere.dcos.client.Config
-import mesosphere.dcos.client.model.DCOSAuthCredentials
 import org.springframework.validation.Errors
 import spock.lang.Shared
-import spock.lang.Specification
 import spock.lang.Subject
 
 import static com.netflix.spinnaker.clouddriver.dcos.deploy.description.loadbalancer.UpsertDcosLoadBalancerAtomicOperationDescription.PortRange
 
-class UpsertDcosLoadBalancerAtomicOperationDescriptionValidatorSpec extends Specification {
+class UpsertDcosLoadBalancerAtomicOperationDescriptionValidatorSpec extends BaseSpecification {
   private static final DESCRIPTION = "upsertDcosLoadBalancerAtomicOperationDescription"
   private static final ACCOUNT = "my-test-account"
 
@@ -21,9 +19,7 @@ class UpsertDcosLoadBalancerAtomicOperationDescriptionValidatorSpec extends Spec
   UpsertDcosLoadBalancerAtomicOperationDescriptionValidator validator
 
   @Shared
-  DcosCredentials testCredentials = new DcosCredentials(
-          ACCOUNT, 'test', 'test', 'url', Config.builder().withCredentials(DCOSAuthCredentials.forUserAccount('user', 'pw')).build()
-  )
+  DcosCredentials testCredentials = defaultCredentialsBuilder().name(ACCOUNT).build()
 
   def setupSpec() {
     def accountCredentialsProvider = Stub(AccountCredentialsProvider) {

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/DeployDcosServerGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/DeployDcosServerGroupDescriptionValidatorSpec.groovy
@@ -1,22 +1,18 @@
 package com.netflix.spinnaker.clouddriver.dcos.deploy.validators.servergroup
 
 import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
+import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.servergroup.DeployDcosServerGroupDescription
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import mesosphere.dcos.client.Config
-import mesosphere.dcos.client.model.DCOSAuthCredentials
 import org.springframework.validation.Errors
-import spock.lang.Specification
 import spock.lang.Subject
 
-class DeployDcosServerGroupDescriptionValidatorSpec extends Specification {
+class DeployDcosServerGroupDescriptionValidatorSpec extends BaseSpecification {
   private static final DESCRIPTION = "deployDcosServerGroupDescription"
   private static final REGION = "default"
 
 
-  def testCredentials = new DcosCredentials(
-    "test", "test", "test", "https://test.url.com", Config.builder().withCredentials(DCOSAuthCredentials.forUserAccount('user', 'pw')).build()
-  )
+  def testCredentials = defaultCredentialsBuilder().build()
 
   def accountCredentialsProvider = Stub(AccountCredentialsProvider) {
     getCredentials("test") >> testCredentials
@@ -49,7 +45,7 @@ class DeployDcosServerGroupDescriptionValidatorSpec extends Specification {
 
   void "validate should give errors when given an invalid DeployDcosServerGroupDescription"() {
     setup:
-      def description = new DeployDcosServerGroupDescription(region: '-iNv.aLiD-', credentials: new DcosCredentials(null, null, null, null, null),
+      def description = new DeployDcosServerGroupDescription(region: '-iNv.aLiD-', credentials: defaultCredentialsBuilder().name(null).build(),
               application: '-iNv.aLiD-', desiredCapacity: 1, cpus: 1, mem: 512, disk: 0, gpus: 0)
       def errorsMock = Mock(Errors)
     when:

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/DestroyDcosServerGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/DestroyDcosServerGroupDescriptionValidatorSpec.groovy
@@ -1,22 +1,18 @@
 package com.netflix.spinnaker.clouddriver.dcos.deploy.validators.servergroup
 
 import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
+import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.servergroup.DestroyDcosServerGroupDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import mesosphere.dcos.client.Config
-import mesosphere.dcos.client.model.DCOSAuthCredentials
 import org.springframework.validation.Errors
-import spock.lang.Specification
 import spock.lang.Subject
 
-class DestroyDcosServerGroupDescriptionValidatorSpec extends Specification {
+class DestroyDcosServerGroupDescriptionValidatorSpec extends BaseSpecification {
   private static final def DESCRIPTION = "destroyDcosServerGroupDescription"
   private static final def INVALID_MARATHON_PART = "-iNv.aLid-"
 
-  DcosCredentials testCredentials = new DcosCredentials(
-    'test', 'test', 'test', 'https://test.url.com', Config.builder().withCredentials(DCOSAuthCredentials.forUserAccount('user', 'pw')).build()
-  )
+  DcosCredentials testCredentials = defaultCredentialsBuilder().build()
 
   AccountCredentialsProvider accountCredentialsProvider = Stub(AccountCredentialsProvider) {
     getCredentials('test') >> testCredentials
@@ -43,7 +39,7 @@ class DestroyDcosServerGroupDescriptionValidatorSpec extends Specification {
 
   void "validate should give errors when given an invalid DestroyDcosServerGroupDescription"() {
     setup:
-      def description = new DestroyDcosServerGroupDescription(region: INVALID_MARATHON_PART, credentials: new DcosCredentials(null, null, null, null, null), serverGroupName: INVALID_MARATHON_PART)
+      def description = new DestroyDcosServerGroupDescription(region: INVALID_MARATHON_PART, credentials: defaultCredentialsBuilder().name(null).build(), serverGroupName: INVALID_MARATHON_PART)
       def errorsMock = Mock(Errors)
     when:
       validator.validate([], description, errorsMock)

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/DisableDcosServerGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/DisableDcosServerGroupDescriptionValidatorSpec.groovy
@@ -1,22 +1,18 @@
 package com.netflix.spinnaker.clouddriver.dcos.deploy.validators.servergroup
 
 import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
+import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.servergroup.DisableDcosServerGroupDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import mesosphere.dcos.client.Config
-import mesosphere.dcos.client.model.DCOSAuthCredentials
 import org.springframework.validation.Errors
-import spock.lang.Specification
 import spock.lang.Subject
 
-class DisableDcosServerGroupDescriptionValidatorSpec extends Specification {
+class DisableDcosServerGroupDescriptionValidatorSpec extends BaseSpecification {
   private static final def DESCRIPTION = "disableDcosServerGroupDescription"
   private static final def INVALID_MARATHON_PART = "-iNv.aLid-"
 
-  DcosCredentials testCredentials = new DcosCredentials(
-    'test', 'test', 'test', 'https://test.url.com', Config.builder().withCredentials(DCOSAuthCredentials.forUserAccount('user', 'pw')).build()
-  )
+  DcosCredentials testCredentials = defaultCredentialsBuilder().build()
 
   AccountCredentialsProvider accountCredentialsProvider = Stub(AccountCredentialsProvider) {
     getCredentials('test') >> testCredentials
@@ -43,7 +39,7 @@ class DisableDcosServerGroupDescriptionValidatorSpec extends Specification {
 
   void "validate should give errors when given an invalid DestroyDcosServerGroupDescription"() {
     setup:
-      def description = new DisableDcosServerGroupDescription(region: INVALID_MARATHON_PART, credentials: new DcosCredentials(null, null, null, null, null), serverGroupName: INVALID_MARATHON_PART)
+      def description = new DisableDcosServerGroupDescription(region: INVALID_MARATHON_PART, credentials: defaultCredentialsBuilder().name(null).build(), serverGroupName: INVALID_MARATHON_PART)
       def errorsMock = Mock(Errors)
     when:
       validator.validate([], description, errorsMock)

--- a/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/ResizeDcosServerGroupDescriptionValidatorSpec.groovy
+++ b/clouddriver-dcos/src/test/groovy/com/netflix/spinnaker/clouddriver/dcos/deploy/validators/servergroup/ResizeDcosServerGroupDescriptionValidatorSpec.groovy
@@ -1,22 +1,18 @@
 package com.netflix.spinnaker.clouddriver.dcos.deploy.validators.servergroup
 
 import com.netflix.spinnaker.clouddriver.dcos.DcosCredentials
+import com.netflix.spinnaker.clouddriver.dcos.deploy.BaseSpecification
 import com.netflix.spinnaker.clouddriver.dcos.deploy.description.servergroup.ResizeDcosServerGroupDescription
 import com.netflix.spinnaker.clouddriver.deploy.DescriptionValidator
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider
-import mesosphere.dcos.client.Config
-import mesosphere.dcos.client.model.DCOSAuthCredentials
 import org.springframework.validation.Errors
-import spock.lang.Specification
 import spock.lang.Subject
 
-class ResizeDcosServerGroupDescriptionValidatorSpec extends Specification {
+class ResizeDcosServerGroupDescriptionValidatorSpec extends BaseSpecification {
   private static final def DESCRIPTION = "resizeDcosServerGroupDescription"
   private static final def INVALID_MARATHON_PART = "-iNv.aLid-"
 
-  DcosCredentials testCredentials = new DcosCredentials(
-    'test', 'test', 'test', 'https://test.url.com', Config.builder().withCredentials(DCOSAuthCredentials.forUserAccount('user', 'pw')).build()
-  )
+  DcosCredentials testCredentials = defaultCredentialsBuilder().build()
 
   AccountCredentialsProvider accountCredentialsProvider = Stub(AccountCredentialsProvider) {
     getCredentials('test') >> testCredentials
@@ -44,7 +40,7 @@ class ResizeDcosServerGroupDescriptionValidatorSpec extends Specification {
 
   void "validate should give errors when given an invalid DestroyDcosServerGroupDescription"() {
     setup:
-      def description = new ResizeDcosServerGroupDescription(region: INVALID_MARATHON_PART, credentials: new DcosCredentials(null, null, null, null, null), serverGroupName: INVALID_MARATHON_PART, targetSize: -1)
+      def description = new ResizeDcosServerGroupDescription(region: INVALID_MARATHON_PART, credentials: defaultCredentialsBuilder().name(null).build(), serverGroupName: INVALID_MARATHON_PART, targetSize: -1)
       def errorsMock = Mock(Errors)
     when:
       validator.validate([], description, errorsMock)


### PR DESCRIPTION
This should isolate the credentials object so future changes don't break tests, while allowing tests to override specific fields if needed for the test.